### PR TITLE
Debt/lists as results

### DIFF
--- a/hdo.cabal
+++ b/hdo.cabal
@@ -26,7 +26,7 @@ Library
                  , Network.DO.Droplets.Commands, Network.DO.Droplets.Net, Network.DO.Droplets.Utils
                  , Network.DO.IP, Network.DO.IP.Commands, Network.DO.IP.Net
                  , Network.DO.Domain, Network.DO.Domain.Commands, Network.DO.Domain.Net
-                 , Network.DO.Tags.Commands, Network.DO.Tags.Net
+                 , Network.DO.Tags, Network.DO.Tags.Commands, Network.DO.Tags.Net
                  , Network.DO.Names, Network.DO.Pairing
                  , Network.REST, Network.DO.Pretty
 

--- a/hdo.cabal
+++ b/hdo.cabal
@@ -26,9 +26,10 @@ Library
                  , Network.DO.Droplets.Commands, Network.DO.Droplets.Net, Network.DO.Droplets.Utils
                  , Network.DO.IP, Network.DO.IP.Commands, Network.DO.IP.Net
                  , Network.DO.Domain, Network.DO.Domain.Commands, Network.DO.Domain.Net
+                 , Network.DO.Tags.Commands, Network.DO.Tags.Net
                  , Network.DO.Names, Network.DO.Pairing
                  , Network.REST, Network.DO.Pretty
-                 
+
   exposed-modules: Network.DO
   Build-Depends: aeson
                , base >= 4 && < 5

--- a/main/hdo.hs
+++ b/main/hdo.hs
@@ -102,10 +102,12 @@ parseCommandOptions ("droplets":"ssh":dropletIdOrName:[])
                                                                  (did:_) -> dropletConsole did
                                                                  []      -> return (error $ "no droplet with id or name " <> dropletIdOrName)
                                                             ) >>= outputResult
+
 parseCommandOptions ("images":"list":_)                  = listImages >>= outputResult
 parseCommandOptions ("regions":"list":_)                 = listRegions >>= outputResult
 parseCommandOptions ("keys":"list":_)                    = listKeys >>= outputResult
 parseCommandOptions ("sizes":"list":_)                   = listSizes >>= outputResult
+
 parseCommandOptions ("ips":"list":_)                     = listFloatingIPs >>= outputResult
 parseCommandOptions ("ips":"create":dropletOrRegion:[])  = do
   regions <- listRegions
@@ -115,6 +117,7 @@ parseCommandOptions ("ips":"create":dropletOrRegion:[])  = do
 parseCommandOptions ("ips":"delete":ip:[])     = deleteFloatingIP (P.read ip) >>= outputResult
 parseCommandOptions ("ips":ip:"assign":did:[]) = assignFloatingIP (P.read ip) (P.read did) >>= outputResult
 parseCommandOptions ("ips":ip:"unassign": [])  = unassignFloatingIP (P.read ip) >>= outputResult
+
 parseCommandOptions ("dns":"list":_)             = listDomains >>= outputResult
 parseCommandOptions ("dns":"create":name:ip:[])  = createDomain (P.read name) (P.read ip) >>= outputResult
 parseCommandOptions ("dns":"delete":name:[])     = deleteDomain (P.read name) >>= outputResult
@@ -124,4 +127,11 @@ parseCommandOptions ("dns":name:"create":rest)   =
     Left (Error e) -> fail e
     Right r        -> createRecord (P.read name) r >>= outputResult
 parseCommandOptions ("dns":name:"delete":rid:[]) = deleteRecord (P.read name) (P.read rid) >>= outputResult
+
+parseCommandOptions ("tags":"list":_) = listTags >>= outputResult
+parseCommandOptions ("tags":"create":name:[]) = createTag name >>= outputResult
+parseCommandOptions ("tags":"delete":name:[]) = deleteTag name >>= outputResult
+parseCommandOptions ("tags":"tag":name:rid:rtype:[]) = tagResources name (TagPairs [TagPair (P.read rid) (P.read rtype)]) >>= outputResult
+parseCommandOptions ("tags":"untag":name:rid:rtype:[]) = untagResources name (TagPairs [TagPair (P.read rid) (P.read rtype)]) >>= outputResult
+
 parseCommandOptions e                          = fail $ "I don't know how to interpret commands " ++ unwords e ++ "\n" ++ usage

--- a/src/Network/DO.hs
+++ b/src/Network/DO.hs
@@ -43,19 +43,19 @@ import qualified Network.DO.Tags.Commands     as C
 type Command w a = FreeT (C.DO :+: C.DropletCommands :+: C.IPCommands :+: C.DomainCommands :+: C.TagsCommands) (RESTT w) a
 
 
-listKeys :: (Monad w) => Command w [Key]
+listKeys :: (Monad w) => Command w (Result [Key])
 listKeys = injl C.listKeys
 
-listSizes :: (Monad w) => Command w [Size]
+listSizes :: (Monad w) => Command w (Result [Size])
 listSizes = injl C.listSizes
 
-listImages  :: (Monad w) => Command w  [Image]
+listImages  :: (Monad w) => Command w  (Result [Image])
 listImages = injl C.listImages
 
-listRegions :: (Monad w) => Command w [Region]
+listRegions :: (Monad w) => Command w (Result [Region])
 listRegions = injl C.listRegions
 
-listFloatingIPs :: (Monad w) => Command w [FloatingIP]
+listFloatingIPs :: (Monad w) => Command w (Result [FloatingIP])
 listFloatingIPs = injrrl C.listFloatingIPs
 
 createFloatingIP :: (Monad w) => FloatingIPTarget -> Command w (Result FloatingIP)
@@ -70,7 +70,7 @@ assignFloatingIP ip did = injrrl $ C.floatingIPAction ip (AssignIP did)
 unassignFloatingIP :: (Monad w) => IP -> Command w (Result (ActionResult IPActionType))
 unassignFloatingIP ip = injrrl $ C.floatingIPAction ip UnassignIP
 
-listDomains :: (Monad w) => Command w [Domain]
+listDomains :: (Monad w) => Command w (Result [Domain])
 listDomains = injrrrl C.listDomains
 
 createDomain :: (Monad w) => DomainName -> IP -> Command w (Result Domain)
@@ -79,7 +79,7 @@ createDomain dname ip = injrrrl $ C.createDomain dname ip
 deleteDomain :: (Monad w) => DomainName -> Command w (Result ())
 deleteDomain = injrrrl . C.deleteDomain
 
-listRecords :: (Monad w) => DomainName -> Command w [DomainRecord]
+listRecords :: (Monad w) => DomainName -> Command w (Result [DomainRecord])
 listRecords = injrrrl . C.listRecords
 
 createRecord :: (Monad w) => DomainName -> DomainRecord -> Command w (Result DomainRecord)
@@ -88,13 +88,13 @@ createRecord dname ip = injrrrl $ C.createRecord dname ip
 deleteRecord :: (Monad w) => DomainName -> Id -> Command w (Result ())
 deleteRecord dname rid = injrrrl $ C.deleteRecord dname rid
 
-listDroplets :: (Monad w) => Command w [Droplet]
+listDroplets :: (Monad w) => Command w (Result [Droplet])
 listDroplets = injrl C.listDroplets
 
-createDroplet :: (Monad w) => BoxConfiguration -> Command w (Either Error Droplet)
+createDroplet :: (Monad w) => BoxConfiguration -> Command w (Result Droplet)
 createDroplet = injrl . C.createDroplet
 
-showDroplet :: (Monad w) => Integer -> Command w (Either Error Droplet)
+showDroplet :: (Monad w) => Integer -> Command w (Result Droplet)
 showDroplet = injrl . C.showDroplet
 
 destroyDroplet :: (Monad w) => Integer -> Command w (Result ())
@@ -109,25 +109,25 @@ dropletConsole = injrl . C.dropletConsole
 getAction :: (Monad w) => Id -> Id -> Command w (Result (ActionResult DropletActionType))
 getAction  did = injrl . C.getAction did
 
-listDropletSnapshots :: (Monad w) => Id -> Command w [Image]
+listDropletSnapshots :: (Monad w) => Id -> Command w (Result [Image])
 listDropletSnapshots = injrl . C.listDropletSnapshots
 
-listTags :: (Monad w) => Command w [Tag]
+listTags :: (Monad w) => Command w (Result [Tag])
 listTags = injrrrr C.listTags
 
-createTag :: (Monad w) => TagName -> Command w (Either Error Tag)
+createTag :: (Monad w) => TagName -> Command w (Result Tag)
 createTag = injrrrr . C.createTag
 
-retrieveTag :: (Monad w) => TagName -> Command w (Either Error Tag)
+retrieveTag :: (Monad w) => TagName -> Command w (Result Tag)
 retrieveTag = injrrrr . C.retrieveTag
 
-deleteTag :: (Monad w) => TagName -> Command w (Either Error ())
+deleteTag :: (Monad w) => TagName -> Command w (Result ())
 deleteTag = injrrrr . C.deleteTag
 
-tagResources :: (Monad w) => TagName -> TagPairs -> Command w (Either Error ())
+tagResources :: (Monad w) => TagName -> TagPairs -> Command w (Result ())
 tagResources name = injrrrr . C.tagResources name
 
-untagResources :: (Monad w) => TagName -> TagPairs -> Command w (Either Error ())
+untagResources :: (Monad w) => TagName -> TagPairs -> Command w (Result ())
 untagResources name = injrrrr . C.untagResources name
 
 

--- a/src/Network/DO.hs
+++ b/src/Network/DO.hs
@@ -56,7 +56,7 @@ listFloatingIPs = injrrl C.listFloatingIPs
 createFloatingIP :: (Monad w) => FloatingIPTarget -> Command w (Result FloatingIP)
 createFloatingIP = injrrl . C.createFloatingIP
 
-deleteFloatingIP :: (Monad w) => IP -> Command w (Maybe String)
+deleteFloatingIP :: (Monad w) => IP -> Command w (Result ())
 deleteFloatingIP = injrrl . C.deleteFloatingIP
 
 assignFloatingIP :: (Monad w) => IP -> Id -> Command w (Result (ActionResult IPActionType))
@@ -71,7 +71,7 @@ listDomains = injrrr C.listDomains
 createDomain :: (Monad w) => DomainName -> IP -> Command w (Result Domain)
 createDomain dname ip = injrrr $ C.createDomain dname ip
 
-deleteDomain :: (Monad w) => DomainName -> Command w (Maybe String)
+deleteDomain :: (Monad w) => DomainName -> Command w (Result ())
 deleteDomain = injrrr . C.deleteDomain
 
 listRecords :: (Monad w) => DomainName -> Command w [DomainRecord]
@@ -80,7 +80,7 @@ listRecords = injrrr . C.listRecords
 createRecord :: (Monad w) => DomainName -> DomainRecord -> Command w (Result DomainRecord)
 createRecord dname ip = injrrr $ C.createRecord dname ip
 
-deleteRecord :: (Monad w) => DomainName -> Id -> Command w (Maybe String)
+deleteRecord :: (Monad w) => DomainName -> Id -> Command w (Result ())
 deleteRecord dname rid = injrrr $ C.deleteRecord dname rid
 
 listDroplets :: (Monad w) => Command w [Droplet]
@@ -92,7 +92,7 @@ createDroplet = injrl . C.createDroplet
 showDroplet :: (Monad w) => Integer -> Command w (Either Error Droplet)
 showDroplet = injrl . C.showDroplet
 
-destroyDroplet :: (Monad w) => Integer -> Command w (Maybe String)
+destroyDroplet :: (Monad w) => Integer -> Command w (Result ())
 destroyDroplet = injrl . C.destroyDroplet
 
 dropletAction :: (Monad w) => Id -> Action -> Command w (Result (ActionResult DropletActionType))

--- a/src/Network/DO.hs
+++ b/src/Network/DO.hs
@@ -42,33 +42,19 @@ import qualified Network.DO.Tags.Commands     as C
 
 type Command w a = FreeT (C.DO :+: C.DropletCommands :+: C.IPCommands :+: C.DomainCommands :+: C.TagsCommands) (RESTT w) a
 
---
--- KEYS
---
+
 listKeys :: (Monad w) => Command w [Key]
 listKeys = injl C.listKeys
 
---
--- SIZES
---
 listSizes :: (Monad w) => Command w [Size]
 listSizes = injl C.listSizes
 
---
--- IMAGES
---
 listImages  :: (Monad w) => Command w  [Image]
 listImages = injl C.listImages
 
---
--- REGIONS
---
 listRegions :: (Monad w) => Command w [Region]
 listRegions = injl C.listRegions
 
---
--- FLOATING IPS
---
 listFloatingIPs :: (Monad w) => Command w [FloatingIP]
 listFloatingIPs = injrrl C.listFloatingIPs
 
@@ -84,9 +70,6 @@ assignFloatingIP ip did = injrrl $ C.floatingIPAction ip (AssignIP did)
 unassignFloatingIP :: (Monad w) => IP -> Command w (Result (ActionResult IPActionType))
 unassignFloatingIP ip = injrrl $ C.floatingIPAction ip UnassignIP
 
---
--- DOMAINS
---
 listDomains :: (Monad w) => Command w [Domain]
 listDomains = injrrrl C.listDomains
 
@@ -96,9 +79,6 @@ createDomain dname ip = injrrrl $ C.createDomain dname ip
 deleteDomain :: (Monad w) => DomainName -> Command w (Result ())
 deleteDomain = injrrrl . C.deleteDomain
 
---
--- RECORDS
---
 listRecords :: (Monad w) => DomainName -> Command w [DomainRecord]
 listRecords = injrrrl . C.listRecords
 
@@ -108,9 +88,6 @@ createRecord dname ip = injrrrl $ C.createRecord dname ip
 deleteRecord :: (Monad w) => DomainName -> Id -> Command w (Result ())
 deleteRecord dname rid = injrrrl $ C.deleteRecord dname rid
 
---
--- DROPLETS
---
 listDroplets :: (Monad w) => Command w [Droplet]
 listDroplets = injrl C.listDroplets
 
@@ -135,9 +112,6 @@ getAction  did = injrl . C.getAction did
 listDropletSnapshots :: (Monad w) => Id -> Command w [Image]
 listDropletSnapshots = injrl . C.listDropletSnapshots
 
---
--- TAGS
---
 listTags :: (Monad w) => Command w [Tag]
 listTags = injrrrr C.listTags
 

--- a/src/Network/DO/Commands.hs
+++ b/src/Network/DO/Commands.hs
@@ -10,33 +10,33 @@ import           Network.DO.Types
 import           Prelude                      as P
 
 -- functor for DO DSL
-data DO a = ListKeys ([Key] -> a)
-          | ListSizes ([Size] -> a)
-          | ListImages ([Image] -> a)
-          | ListRegions ([Region] -> a)
+data DO a = ListKeys (Result [Key] -> a)
+          | ListSizes (Result [Size] -> a)
+          | ListImages (Result [Image] -> a)
+          | ListRegions (Result [Region] -> a)
           deriving (Functor)
 
 -- free transformer to embed effects
 type DOT = FreeT DO
 
 -- smart constructors
-listKeys :: DO [Key]
+listKeys :: DO (Result [Key])
 listKeys = ListKeys P.id
 
-listSizes :: DO [Size]
+listSizes :: DO (Result [Size])
 listSizes = ListSizes P.id
 
-listImages  :: DO [Image]
+listImages  :: DO (Result [Image])
 listImages = ListImages P.id
 
-listRegions :: DO [Region]
+listRegions :: DO (Result [Region])
 listRegions = ListRegions P.id
 
 -- dual type, for creating interpreters
-data CoDO m k = CoDO { listKeysH    :: (m [Key], k)
-                     , listSizesH   :: (m [Size], k)
-                     , listImagesH  :: (m [Image], k)
-                     , listRegionsH :: (m [Region], k)
+data CoDO m k = CoDO { listKeysH    :: (m (Result [Key]), k)
+                     , listSizesH   :: (m (Result [Size]), k)
+                     , listImagesH  :: (m (Result [Image]), k)
+                     , listRegionsH :: (m (Result [Region]), k)
                      } deriving Functor
 
 -- Cofree closure of CoDO functor

--- a/src/Network/DO/Domain/Commands.hs
+++ b/src/Network/DO/Domain/Commands.hs
@@ -10,10 +10,10 @@ import           Network.DO.Pairing
 import           Network.DO.Types
 import           Prelude                      as P
 
-data DomainCommands a = ListDomains ([Domain] -> a)
+data DomainCommands a = ListDomains (Result [Domain] -> a)
                       | CreateDomain DomainName IP (Result Domain -> a)
                       | DeleteDomain DomainName (Result () -> a)
-                      | ListRecords DomainName ([DomainRecord] -> a)
+                      | ListRecords DomainName (Result [DomainRecord] -> a)
                       | CreateRecord DomainName DomainRecord (Result DomainRecord -> a)
                       | DeleteRecord DomainName Id (Result () -> a)
                       deriving (Functor)
@@ -21,7 +21,7 @@ data DomainCommands a = ListDomains ([Domain] -> a)
 type DomainCommandsT = FreeT DomainCommands
 
 -- smart constructors
-listDomains :: DomainCommands [Domain]
+listDomains :: DomainCommands (Result [Domain])
 listDomains = ListDomains P.id
 
 createDomain :: DomainName -> IP -> DomainCommands (Result Domain)
@@ -30,7 +30,7 @@ createDomain dname ip = CreateDomain dname ip P.id
 deleteDomain :: DomainName -> DomainCommands (Result ())
 deleteDomain ip = DeleteDomain ip P.id
 
-listRecords :: DomainName -> DomainCommands [DomainRecord]
+listRecords :: DomainName -> DomainCommands (Result [DomainRecord])
 listRecords n = ListRecords n P.id
 
 createRecord :: DomainName -> DomainRecord -> DomainCommands (Result DomainRecord)
@@ -41,10 +41,10 @@ deleteRecord dname rid = DeleteRecord dname rid P.id
 
 -- dual type, for creating interpreters
 data CoDomainCommands m k =
-  CoDomainCommands { listDomainsH  :: (m [Domain], k)
+  CoDomainCommands { listDomainsH  :: (m (Result [Domain]), k)
                    , createDomainH :: DomainName -> IP -> (m (Result Domain), k)
                    , deleteDomainH :: DomainName -> (m (Result ()), k)
-                   , listRecordsH  :: DomainName -> (m [DomainRecord], k)
+                   , listRecordsH  :: DomainName -> (m (Result [DomainRecord]), k)
                    , createRecordH :: DomainName -> DomainRecord -> (m (Result DomainRecord), k)
                    , deleteRecordH :: DomainName -> Id -> (m (Result ()), k)
                    } deriving Functor

--- a/src/Network/DO/Domain/Commands.hs
+++ b/src/Network/DO/Domain/Commands.hs
@@ -12,10 +12,10 @@ import           Prelude                      as P
 
 data DomainCommands a = ListDomains ([Domain] -> a)
                       | CreateDomain DomainName IP (Result Domain -> a)
-                      | DeleteDomain DomainName (Maybe String -> a)
+                      | DeleteDomain DomainName (Result () -> a)
                       | ListRecords DomainName ([DomainRecord] -> a)
                       | CreateRecord DomainName DomainRecord (Result DomainRecord -> a)
-                      | DeleteRecord DomainName Id (Maybe String -> a)
+                      | DeleteRecord DomainName Id (Result () -> a)
                       deriving (Functor)
 
 type DomainCommandsT = FreeT DomainCommands
@@ -27,7 +27,7 @@ listDomains = ListDomains P.id
 createDomain :: DomainName -> IP -> DomainCommands (Result Domain)
 createDomain dname ip = CreateDomain dname ip P.id
 
-deleteDomain :: DomainName -> DomainCommands (Maybe String)
+deleteDomain :: DomainName -> DomainCommands (Result ())
 deleteDomain ip = DeleteDomain ip P.id
 
 listRecords :: DomainName -> DomainCommands [DomainRecord]
@@ -36,17 +36,17 @@ listRecords n = ListRecords n P.id
 createRecord :: DomainName -> DomainRecord -> DomainCommands (Result DomainRecord)
 createRecord dname record = CreateRecord dname record P.id
 
-deleteRecord :: DomainName -> Id -> DomainCommands (Maybe String)
+deleteRecord :: DomainName -> Id -> DomainCommands (Result ())
 deleteRecord dname rid = DeleteRecord dname rid P.id
 
 -- dual type, for creating interpreters
 data CoDomainCommands m k =
   CoDomainCommands { listDomainsH  :: (m [Domain], k)
                    , createDomainH :: DomainName -> IP -> (m (Result Domain), k)
-                   , deleteDomainH :: DomainName -> (m (Maybe String), k)
+                   , deleteDomainH :: DomainName -> (m (Result ()), k)
                    , listRecordsH  :: DomainName -> (m [DomainRecord], k)
                    , createRecordH :: DomainName -> DomainRecord -> (m (Result DomainRecord), k)
-                   , deleteRecordH :: DomainName -> Id -> (m (Maybe String), k)
+                   , deleteRecordH :: DomainName -> Id -> (m (Result ()), k)
                    } deriving Functor
 
 -- Cofree closure of CoDomainCommands functor

--- a/src/Network/DO/Domain/Net.hs
+++ b/src/Network/DO/Domain/Net.hs
@@ -45,7 +45,7 @@ doCreateDomain w name ip = maybe (return $ error "no authentication token define
 
 doDeleteDomain :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> DomainName -> (RESTT m (Maybe String), w a)
 doDeleteDomain w name = maybe (return $ Just "no authentication token defined", w)
-                  (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ domainsEndpoint </> show name) >> return Nothing
+                  (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ domainsEndpoint </> show name) (toJSON ()) >> return Nothing
                           in (r, w))
                   (authToken (ask w))
 
@@ -68,7 +68,7 @@ doCreateRecord w name record =
 doDeleteRecord :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> DomainName -> Id -> (RESTT m (Maybe String), w a)
 doDeleteRecord w name rid =
   maybe (return $ Just "no authentication token defined", w)
-  (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ domainsEndpoint </> show name </> "records" </> show rid ) >> return Nothing
+  (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ domainsEndpoint </> show name </> "records" </> show rid ) (toJSON ()) >> return Nothing
           in (r, w))
   (authToken (ask w))
 

--- a/src/Network/DO/Domain/Net.hs
+++ b/src/Network/DO/Domain/Net.hs
@@ -49,9 +49,9 @@ doDeleteDomain w name = maybe (errMissingToken, w)
                           in (r, w))
                   (authToken (ask w))
 
-doListRecords :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> DomainName -> (RESTT m [DomainRecord], w a)
-doListRecords w name = maybe (return [], w)
-                       (\ t -> let records = toList "domain_records" <$> getJSONWith (authorisation t) (toURI $ domainsEndpoint </> show name </> "records")
+doListRecords :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> DomainName -> (RESTT m (Result [DomainRecord]), w a)
+doListRecords w name = maybe (errMissingToken, w)
+                       (\ t -> let records = Right . toList "domain_records" <$> getJSONWith (authorisation t) (toURI $ domainsEndpoint </> show name </> "records")
                          in (records, w))
                        (authToken (ask w))
 

--- a/src/Network/DO/Domain/Net.hs
+++ b/src/Network/DO/Domain/Net.hs
@@ -51,7 +51,7 @@ doDeleteDomain w name = maybe (errMissingToken, w)
 
 doListRecords :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> DomainName -> (RESTT m (Result [DomainRecord]), w a)
 doListRecords w name = maybe (errMissingToken, w)
-                       (\ t -> let records = Right . toList "domain_records" <$> getJSONWith (authorisation t) (toURI $ domainsEndpoint </> show name </> "records")
+                       (\ t -> let records = toList "domain_records" <$> getJSONWith (authorisation t) (toURI $ domainsEndpoint </> show name </> "records")
                          in (records, w))
                        (authToken (ask w))
 

--- a/src/Network/DO/Droplets/Commands.hs
+++ b/src/Network/DO/Droplets/Commands.hs
@@ -15,12 +15,12 @@ import           Network.DO.Types
 import           Prelude                      as P
 
 -- | Available commands for droplets
-data DropletCommands a = ListDroplets ([Droplet] -> a)
+data DropletCommands a = ListDroplets (Result [Droplet] -> a)
                        | CreateDroplet BoxConfiguration (Result Droplet -> a)
                        | DestroyDroplet Id (Result () -> a)
                        | DropletAction Id Action (Result (ActionResult DropletActionType) -> a)
                        | GetAction Id Id (Result (ActionResult DropletActionType) -> a)
-                       | ListSnapshots Id ([Image] -> a)
+                       | ListSnapshots Id (Result [Image] -> a)
                        | Console Droplet (Result () -> a)
                        | ShowDroplet Id (Result Droplet -> a)
                        deriving (Functor)
@@ -29,7 +29,7 @@ data DropletCommands a = ListDroplets ([Droplet] -> a)
 type DropletCommandsT = FreeT DropletCommands
 
 -- smart constructors
-listDroplets :: DropletCommands [Droplet]
+listDroplets :: DropletCommands (Result [Droplet])
 listDroplets = ListDroplets P.id
 
 createDroplet :: BoxConfiguration -> DropletCommands (Result Droplet)
@@ -50,17 +50,17 @@ dropletConsole droplet = Console droplet P.id
 getAction :: Id -> Id -> DropletCommands (Result (ActionResult DropletActionType))
 getAction did actId = GetAction did actId P.id
 
-listDropletSnapshots :: Id -> DropletCommands [Image]
+listDropletSnapshots :: Id -> DropletCommands (Result [Image])
 listDropletSnapshots did = ListSnapshots did P.id
 
 
 -- | Comonadic interpreter for @DropletCommands@
-data CoDropletCommands m k = CoDropletCommands { listDropletsH   :: (m [Droplet], k)
+data CoDropletCommands m k = CoDropletCommands { listDropletsH   :: (m (Result [Droplet]), k)
                                                , createDropletH  :: BoxConfiguration -> (m (Result Droplet), k)
                                                , destroyDropletH :: Id -> (m (Result ()), k)
                                                , actionDropletH  :: Id -> Action -> (m (Result (ActionResult DropletActionType)), k)
                                                , getActionH      :: Id -> Id -> (m (Result (ActionResult DropletActionType)), k)
-                                               , listSnapshotsH  :: Id -> (m [Image], k)
+                                               , listSnapshotsH  :: Id -> (m (Result [Image]), k)
                                                , consoleH        :: Droplet -> (m (Result ()), k)
                                                , showDropletH    :: Id -> (m (Result Droplet), k)
                                                } deriving Functor

--- a/src/Network/DO/Droplets/Commands.hs
+++ b/src/Network/DO/Droplets/Commands.hs
@@ -17,7 +17,7 @@ import           Prelude                      as P
 -- | Available commands for droplets
 data DropletCommands a = ListDroplets ([Droplet] -> a)
                        | CreateDroplet BoxConfiguration (Result Droplet -> a)
-                       | DestroyDroplet Id (Maybe String -> a)
+                       | DestroyDroplet Id (Result () -> a)
                        | DropletAction Id Action (Result (ActionResult DropletActionType) -> a)
                        | GetAction Id Id (Result (ActionResult DropletActionType) -> a)
                        | ListSnapshots Id ([Image] -> a)
@@ -38,7 +38,7 @@ createDroplet conf = CreateDroplet conf P.id
 showDroplet :: Id -> DropletCommands (Result Droplet)
 showDroplet did = ShowDroplet did P.id
 
-destroyDroplet :: Id -> DropletCommands (Maybe String)
+destroyDroplet :: Id -> DropletCommands (Result ())
 destroyDroplet did = DestroyDroplet did P.id
 
 dropletAction :: Id -> Action -> DropletCommands (Result (ActionResult DropletActionType))
@@ -57,7 +57,7 @@ listDropletSnapshots did = ListSnapshots did P.id
 -- | Comonadic interpreter for @DropletCommands@
 data CoDropletCommands m k = CoDropletCommands { listDropletsH   :: (m [Droplet], k)
                                                , createDropletH  :: BoxConfiguration -> (m (Result Droplet), k)
-                                               , destroyDropletH :: Id -> (m (Maybe String), k)
+                                               , destroyDropletH :: Id -> (m (Result ()), k)
                                                , actionDropletH  :: Id -> Action -> (m (Result (ActionResult DropletActionType)), k)
                                                , getActionH      :: Id -> Id -> (m (Result (ActionResult DropletActionType)), k)
                                                , listSnapshotsH  :: Id -> (m [Image], k)

--- a/src/Network/DO/Droplets/Net.hs
+++ b/src/Network/DO/Droplets/Net.hs
@@ -28,10 +28,10 @@ instance Listable Droplet where
   listEndpoint _ = dropletsEndpoint
   listField _    = "droplets"
 
-doListSnapshots :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> Id -> (RESTT m [Image], w a)
+doListSnapshots :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> Id -> (RESTT m (Result [Image]), w a)
 doListSnapshots w dropletId =
-  maybe (return [], w)
-  (\ t -> let snapshots = toList "snapshots" <$> getJSONWith (authorisation t) (toURI $ dropletsEndpoint </> show dropletId </> "snapshots")
+  maybe (errMissingToken, w)
+  (\ t -> let snapshots = Right . toList "snapshots" <$> getJSONWith (authorisation t) (toURI $ dropletsEndpoint </> show dropletId </> "snapshots")
           in (snapshots, w))
   (authToken (ask w))
 

--- a/src/Network/DO/Droplets/Net.hs
+++ b/src/Network/DO/Droplets/Net.hs
@@ -31,7 +31,7 @@ instance Listable Droplet where
 doListSnapshots :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> Id -> (RESTT m (Result [Image]), w a)
 doListSnapshots w dropletId =
   maybe (errMissingToken, w)
-  (\ t -> let snapshots = Right . toList "snapshots" <$> getJSONWith (authorisation t) (toURI $ dropletsEndpoint </> show dropletId </> "snapshots")
+  (\ t -> let snapshots = toList "snapshots" <$> getJSONWith (authorisation t) (toURI $ dropletsEndpoint </> show dropletId </> "snapshots")
           in (snapshots, w))
   (authToken (ask w))
 

--- a/src/Network/DO/Droplets/Net.hs
+++ b/src/Network/DO/Droplets/Net.hs
@@ -51,7 +51,7 @@ doCreate w config = maybe (return $ error "no authentication token defined", w)
 
 doDestroyDroplet :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> Id -> (RESTT m (Maybe String), w a)
 doDestroyDroplet w dropletId = maybe (return $ Just "no authentication token defined", w)
-                               (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ dropletsEndpoint </> show dropletId) >> return Nothing
+                               (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ dropletsEndpoint </> show dropletId) (toJSON ()) >> return Nothing
                                        in (r, w))
                                (authToken (ask w))
 

--- a/src/Network/DO/IP/Commands.hs
+++ b/src/Network/DO/IP/Commands.hs
@@ -13,7 +13,7 @@ import           Prelude                      as P
 -- functor for DO DSL
 data IPCommands a = ListFloatingIPs ([FloatingIP] -> a)
                   | CreateIP FloatingIPTarget (Result FloatingIP -> a)
-                  | DeleteIP IP (Maybe String -> a)
+                  | DeleteIP IP (Result () -> a)
                   | ActionIP IP IPAction (Result (ActionResult IPActionType) -> a)
           deriving (Functor)
 
@@ -27,7 +27,7 @@ listFloatingIPs = ListFloatingIPs P.id
 createFloatingIP :: FloatingIPTarget -> IPCommands (Result FloatingIP)
 createFloatingIP target = CreateIP target P.id
 
-deleteFloatingIP :: IP -> IPCommands (Maybe String)
+deleteFloatingIP :: IP -> IPCommands (Result ())
 deleteFloatingIP ip = DeleteIP ip P.id
 
 floatingIPAction :: IP -> IPAction -> IPCommands (Result (ActionResult IPActionType))
@@ -37,7 +37,7 @@ floatingIPAction ip action = ActionIP ip action P.id
 data CoIPCommands m k =
   CoIPCommands { listFloatingIPsH  :: (m [FloatingIP], k)
                , createFloatingIPH :: FloatingIPTarget -> (m (Result FloatingIP), k)
-               , deleteIPH         :: IP -> (m (Maybe String), k)
+               , deleteIPH         :: IP -> (m (Result ()), k)
                , actionIPH         :: IP -> IPAction -> (m (Result (ActionResult IPActionType)), k)
                } deriving Functor
 

--- a/src/Network/DO/IP/Commands.hs
+++ b/src/Network/DO/IP/Commands.hs
@@ -11,7 +11,7 @@ import           Network.DO.Types
 import           Prelude                      as P
 
 -- functor for DO DSL
-data IPCommands a = ListFloatingIPs ([FloatingIP] -> a)
+data IPCommands a = ListFloatingIPs (Result [FloatingIP] -> a)
                   | CreateIP FloatingIPTarget (Result FloatingIP -> a)
                   | DeleteIP IP (Result () -> a)
                   | ActionIP IP IPAction (Result (ActionResult IPActionType) -> a)
@@ -21,7 +21,7 @@ data IPCommands a = ListFloatingIPs ([FloatingIP] -> a)
 type IPCommandsT = FreeT IPCommands
 
 -- smart constructors
-listFloatingIPs :: IPCommands [FloatingIP]
+listFloatingIPs :: IPCommands (Result [FloatingIP])
 listFloatingIPs = ListFloatingIPs P.id
 
 createFloatingIP :: FloatingIPTarget -> IPCommands (Result FloatingIP)
@@ -35,7 +35,7 @@ floatingIPAction ip action = ActionIP ip action P.id
 
 -- dual type, for creating interpreters
 data CoIPCommands m k =
-  CoIPCommands { listFloatingIPsH  :: (m [FloatingIP], k)
+  CoIPCommands { listFloatingIPsH  :: (m (Result [FloatingIP]), k)
                , createFloatingIPH :: FloatingIPTarget -> (m (Result FloatingIP), k)
                , deleteIPH         :: IP -> (m (Result ()), k)
                , actionIPH         :: IP -> IPAction -> (m (Result (ActionResult IPActionType)), k)

--- a/src/Network/DO/IP/Net.hs
+++ b/src/Network/DO/IP/Net.hs
@@ -42,7 +42,7 @@ doCreateIP w config = maybe (return $ error "no authentication token defined", w
 
 doDeleteIP :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> IP -> (RESTT m (Maybe String), w a)
 doDeleteIP w ip = maybe (return $ Just "no authentication token defined", w)
-                  (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ floatingIpsEndpoint </> show ip) >> return Nothing
+                  (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ floatingIpsEndpoint </> show ip) (toJSON ()) >> return Nothing
                           in (r, w))
                   (authToken (ask w))
 

--- a/src/Network/DO/IP/Net.hs
+++ b/src/Network/DO/IP/Net.hs
@@ -32,22 +32,22 @@ instance Listable FloatingIP where
   listField _    = "floating_ips"
 
 doCreateIP :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> FloatingIPTarget -> (RESTT m (Result FloatingIP), w a)
-doCreateIP w config = maybe (return $ error "no authentication token defined", w)
+doCreateIP w config = maybe (errMissingToken, w)
   runQuery
   (authToken (ask w))
   where
-    runQuery t = let opts             = authorisation t
-                     ip               = postJSONWith opts (toURI floatingIpsEndpoint) (toJSON config) >>= return . fromResponse "floating_ip"
+    runQuery t = let opts = authorisation t
+                     ip   = postJSONWith opts (toURI floatingIpsEndpoint) (toJSON config) >>= return . fromResponse "floating_ip"
                  in (ip, w)
 
-doDeleteIP :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> IP -> (RESTT m (Maybe String), w a)
-doDeleteIP w ip = maybe (return $ Just "no authentication token defined", w)
-                  (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ floatingIpsEndpoint </> show ip) (toJSON ()) >> return Nothing
+doDeleteIP :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> IP -> (RESTT m (Result ()), w a)
+doDeleteIP w ip = maybe (errMissingToken, w)
+                  (\ t -> let r = deleteJSONWith (authorisation t) (toURI $ floatingIpsEndpoint </> show ip) (toJSON ()) >> return (Right ())
                           in (r, w))
                   (authToken (ask w))
 
 doAction :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> IP -> IPAction -> (RESTT m (Result (ActionResult IPActionType)), w a)
-doAction w ip action = maybe (return $ error "no authentication token defined", w)
+doAction w ip action = maybe (errMissingToken, w)
                        (\ t -> let r = postJSONWith (authorisation t) (toURI $ floatingIpsEndpoint </> show ip </> "actions") (toJSON action)
                                        >>= return . fromResponse "action"
                                in (r, w))

--- a/src/Network/DO/Net.hs
+++ b/src/Network/DO/Net.hs
@@ -23,6 +23,7 @@ import           Network.DO.Domain
 import           Network.DO.Droplets.Commands
 import           Network.DO.Droplets.Net
 import           Network.DO.IP
+import           Network.DO.Tags
 import           Network.DO.Net.Common
 import           Network.DO.Pairing
 import           Network.DO.Types             as DO hiding (URI)
@@ -79,7 +80,7 @@ genericCommands = CoDO
                   <*> queryList (Proxy :: Proxy Region)
 
 mkDOClient :: (MonadIO m) => ToolConfiguration
-           -> CofreeT (CoDO (RESTT m) :*: CoDropletCommands (RESTT m) :*: CoIPCommands (RESTT m) :*: CoDomainCommands (RESTT m)) (Env ToolConfiguration) (RESTT m ())
+           -> CofreeT (CoDO (RESTT m) :*: CoDropletCommands (RESTT m) :*: CoIPCommands (RESTT m) :*: CoDomainCommands (RESTT m) :*: CoTagsCommands (RESTT m)) (Env ToolConfiguration) (RESTT m ())
 mkDOClient config = coiterT next start
   where
     next = Pair
@@ -88,7 +89,10 @@ mkDOClient config = coiterT next start
                  <$> dropletCommandsInterpreter
                  <*> (Pair
                       <$> ipCommandsInterpreter
-                      <*> dnsCommandsInterpreter
+                      <*> (Pair
+                           <$> dnsCommandsInterpreter
+                           <*> tagsCommandsInterpreter
+                          )
                      )
                )
     start = env config (return ())

--- a/src/Network/DO/Net/Common.hs
+++ b/src/Network/DO/Net/Common.hs
@@ -38,9 +38,12 @@ class Listable a where
 
 queryList :: (ComonadEnv ToolConfiguration w, Monad m, Listable b, FromJSON b) => Proxy b -> w a -> (RESTT m [b], w a)
 queryList p w = maybe (return [], w)
-                (\ t -> let droplets = toList (listField p) <$> getJSONWith (authorisation t) (toURI (listEndpoint p))
-                        in (droplets, w))
+                (\ t -> let resources = toList (listField p) <$> getJSONWith (authorisation t) (toURI (listEndpoint p))
+                        in (resources, w))
                 (authToken (ask w))
+
+errMissingToken :: (Monad m) => m (Result a)
+errMissingToken = return $ error "no authentication token defined"
 
 -- |Extract a typed result from a JSON output
 fromResponse :: (FromJSON a) => Text -> Either String Value -> Result a

--- a/src/Network/DO/Net/Common.hs
+++ b/src/Network/DO/Net/Common.hs
@@ -36,9 +36,9 @@ class Listable a where
   listEndpoint :: Proxy a -> String
   listField :: Proxy a -> Text
 
-queryList :: (ComonadEnv ToolConfiguration w, Monad m, Listable b, FromJSON b) => Proxy b -> w a -> (RESTT m [b], w a)
-queryList p w = maybe (return [], w)
-                (\ t -> let resources = toList (listField p) <$> getJSONWith (authorisation t) (toURI (listEndpoint p))
+queryList :: (ComonadEnv ToolConfiguration w, Monad m, Listable b, FromJSON b) => Proxy b -> w a -> (RESTT m (Result [b]), w a)
+queryList p w = maybe (errMissingToken, w)
+                (\ t -> let resources = Right . toList (listField p) <$> getJSONWith (authorisation t) (toURI (listEndpoint p))
                         in (resources, w))
                 (authToken (ask w))
 

--- a/src/Network/DO/Pairing.hs
+++ b/src/Network/DO/Pairing.hs
@@ -19,6 +19,7 @@ module Network.DO.Pairing (Pairing(..)
                , injr, injl
                , injrl, injrr
                , injrrl, injrrr
+               , injrrrl, injrrrr
                ) where
 
 import           Control.Comonad              (Comonad, extract)
@@ -80,6 +81,13 @@ injrrl = liftF . InR . InR . InL
 
 injrrr :: (Monad m, Functor f, Functor g, Functor h, Functor k) => k a -> FreeT (f :+: g :+: h :+: k) m a
 injrrr = liftF . InR . InR . InR
+
+injrrrl :: (Monad m, Functor f, Functor g, Functor h, Functor k, Functor l) => k a -> FreeT (f :+: g :+: h :+: k :+: l) m a
+injrrrl = liftF . InR . InR . InR . InL
+
+injrrrr :: (Monad m, Functor f, Functor g, Functor h, Functor k, Functor l) => l a -> FreeT (f :+: g :+: h :+: k :+: l) m a
+injrrrr = liftF . InR . InR . InR . InR
+
 
 pairEffect :: (Pairing f g, Comonad w, Monad m)
            => (a -> b -> r) -> CofreeT f w a -> FreeT g m b -> m r

--- a/src/Network/DO/Pretty.hs
+++ b/src/Network/DO/Pretty.hs
@@ -111,6 +111,18 @@ instance Pretty DomainRecord where
 
 instance Pretty DNSType
 
+instance Pretty Tag where
+  pretty Tag{..} = text tagName $$
+                   nest 5 (text "droplets" <+> (brackets $ int $ tagDropletsCount $ tagDroplets tagResources)) $$
+                   nest 10 (maybe (text "<none>") pretty (tagDropletsLastTagged $ tagDroplets tagResources)) $$
+                   nest 5 (text "volumes" <+> (brackets $ int $ tagVolumesCount $ tagVolumes tagResources))    $$
+                   nest 10 (maybe (text "<none>") pretty (tagVolumesLastTagged $ tagVolumes tagResources))
+
+instance Pretty Volume where
+  pretty Volume{..} = integer volumeId $$
+                      nest 5 (text volumeName <+> brackets (int volumeSizeGigaBytes <> text "GiB") <+> pretty volumeRegion) $$
+                      nest 5 (hcat $ punctuate (char ',') $ integer <$> volumeDropletIds)
+
 outputResult :: (Pretty a, MonadIO m) => a -> m  ()
 outputResult = liftIO . putStrLn . render . pretty
 

--- a/src/Network/DO/Tags.hs
+++ b/src/Network/DO/Tags.hs
@@ -1,0 +1,6 @@
+module Network.DO.Tags(module Network.DO.Tags.Commands
+                      ,module Network.DO.Tags.Net
+                      ) where
+
+import           Network.DO.Tags.Commands
+import           Network.DO.Tags.Net

--- a/src/Network/DO/Tags/Commands.hs
+++ b/src/Network/DO/Tags/Commands.hs
@@ -21,7 +21,7 @@ import Network.DO.Types hiding (TagResources, tagResources, name)
 data TagsCommands a = CreateTag TagName (Result Tag -> a)
                     | RetrieveTag TagName (Result Tag -> a)
                     | DeleteTag TagName (Result () -> a)
-                    | ListTags ([Tag] -> a)
+                    | ListTags (Result [Tag] -> a)
                     | TagResources TagName TagPairs (Result () -> a)
                     | UntagResources TagName TagPairs (Result () -> a)
                     deriving (Functor)
@@ -39,7 +39,7 @@ retrieveTag name = RetrieveTag name Prelude.id
 deleteTag :: TagName -> TagsCommands (Result ())
 deleteTag name = DeleteTag name Prelude.id
 
-listTags :: TagsCommands [Tag]
+listTags :: TagsCommands (Result [Tag])
 listTags = ListTags Prelude.id
 
 tagResources :: TagName -> TagPairs -> TagsCommands (Result ())
@@ -52,7 +52,7 @@ untagResources name pairs = TagResources name pairs Prelude.id
 data CoTagsCommands m k = CoTagsCommands { createTagH      :: TagName -> (m (Result Tag), k)
                                          , retrieveTagH    :: TagName -> (m (Result Tag), k)
                                          , deleteTagH      :: TagName -> (m (Result ()), k)
-                                         , listTagsH       :: (m [Tag], k)
+                                         , listTagsH       :: (m (Result [Tag]), k)
                                          , tagResourcesH   :: TagName -> TagPairs -> (m (Result ()), k)
                                          , untagResourcesH :: TagName -> TagPairs -> (m (Result ()), k)
                                          } deriving Functor

--- a/src/Network/DO/Tags/Commands.hs
+++ b/src/Network/DO/Tags/Commands.hs
@@ -17,8 +17,6 @@ import Control.Monad.Trans.Free
 import Network.DO.Pairing
 import Network.DO.Types hiding (TagResources, tagResources, name)
 
-type TagName = String
-
 -- | Available commands for tags
 data TagsCommands a = CreateTag TagName (Result Tag -> a)
                     | RetrieveTag TagName (Result Tag -> a)

--- a/src/Network/DO/Tags/Commands.hs
+++ b/src/Network/DO/Tags/Commands.hs
@@ -26,7 +26,7 @@ data TagsCommands a = CreateTag TagName (Result Tag -> a)
                     | UntagResources TagName TagPairs (Result () -> a)
                     deriving (Functor)
 
--- free transformer to embed effects
+-- | free transformer to embed effects
 type TagsCommandsT = FreeT TagsCommands
 
 -- smart constructors

--- a/src/Network/DO/Tags/Commands.hs
+++ b/src/Network/DO/Tags/Commands.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Network.DO.Tags.Commands(TagsCommands,
+                                TagsCommandsT, CoTagsCommandsT,
+                                CoTagsCommands(..),
+                                TagName,
+                                createTag, retrieveTag, listTags,
+                                tagResources, untagResources,
+                                deleteTag) where
+
+import Prelude
+
+import Control.Comonad.Trans.Cofree
+import Control.Monad.Trans.Free
+import Network.DO.Pairing
+import Network.DO.Types hiding (TagResources, tagResources, name)
+
+type TagName = String
+
+-- | Available commands for tags
+data TagsCommands a = CreateTag TagName (Result Tag -> a)
+                    | RetrieveTag TagName (Result Tag -> a)
+                    | DeleteTag TagName (Result () -> a)
+                    | ListTags ([Tag] -> a)
+                    | TagResources TagName TagPairs (Result () -> a)
+                    | UntagResources TagName TagPairs (Result () -> a)
+                    deriving (Functor)
+
+-- free transformer to embed effects
+type TagsCommandsT = FreeT TagsCommands
+
+-- smart constructors
+createTag :: TagName -> TagsCommands (Result Tag)
+createTag name = CreateTag name Prelude.id
+
+retrieveTag :: TagName -> TagsCommands (Result Tag)
+retrieveTag name = RetrieveTag name Prelude.id
+
+deleteTag :: TagName -> TagsCommands (Result ())
+deleteTag name = DeleteTag name Prelude.id
+
+listTags :: TagsCommands [Tag]
+listTags = ListTags Prelude.id
+
+tagResources :: TagName -> TagPairs -> TagsCommands (Result ())
+tagResources name pairs = TagResources name pairs Prelude.id
+
+untagResources :: TagName -> TagPairs -> TagsCommands (Result ())
+untagResources name pairs = TagResources name pairs Prelude.id
+
+-- | Comonadic interpreter for @Tagscommands@
+data CoTagsCommands m k = CoTagsCommands { createTagH      :: TagName -> (m (Result Tag), k)
+                                         , retrieveTagH    :: TagName -> (m (Result Tag), k)
+                                         , deleteTagH      :: TagName -> (m (Result ()), k)
+                                         , listTagsH       :: (m [Tag], k)
+                                         , tagResourcesH   :: TagName -> TagPairs -> (m (Result ()), k)
+                                         , untagResourcesH :: TagName -> TagPairs -> (m (Result ()), k)
+                                         } deriving Functor
+
+-- | Cofree closure of CoTagsCommands functor
+type CoTagsCommandsT m = CofreeT (CoTagsCommands m)
+
+-- Pair DSL with interpreter within some monadic context
+instance (Monad m) => PairingM (CoTagsCommands m) TagsCommands m where
+  pairM f (CoTagsCommands create _ _ _ _ _)   (CreateTag name k)       = pairM f (create name) k
+  pairM f (CoTagsCommands _ retrieve _ _ _ _) (RetrieveTag name k)     = pairM f (retrieve name) k
+  pairM f (CoTagsCommands _ _ delete _ _ _)   (DeleteTag name k)       = pairM f (delete name) k
+  pairM f (CoTagsCommands _ _ _ list _ _)     (ListTags k)             = pairM f list k
+  pairM f (CoTagsCommands _ _ _ _ tag _)      (TagResources name pairs k)   = pairM f (tag name pairs) k
+  pairM f (CoTagsCommands _ _ _ _ _ untag)    (UntagResources name pairs k) = pairM f (untag name pairs) k

--- a/src/Network/DO/Tags/Net.hs
+++ b/src/Network/DO/Tags/Net.hs
@@ -19,10 +19,11 @@ import Network.DO.Types             as DO hiding (URI, name)
 import Network.REST
 
 
--- Define some shortcut accessor
+-- | Resource identifier for tags
 tagsURI :: String
 tagsURI = "tags"
 
+-- | Root endpoint for tags
 tagsEndpoint :: String
 tagsEndpoint = rootURI </> apiVersion </> tagsURI
 
@@ -35,6 +36,7 @@ instance Listable Tag where
   listEndpoint _ = tagsEndpoint
   listField    _ = "tags"
 
+-- | Create a new Tag
 --
 -- https://developers.digitalocean.com/documentation/v2/#create-a-new-tag
 --
@@ -46,6 +48,7 @@ doCreateTag w name = maybe (errMissingToken, w) runQuery (authToken (ask w))
                      query = fromResponse "tag" <$> postJSONWith opts (toURI tagsEndpoint) body
                  in (query, w)
 
+-- | Retrieve a Tag
 --
 -- https://developers.digitalocean.com/documentation/v2/#retrieve-a-tag
 --
@@ -56,6 +59,7 @@ doRetrieveTag w name = maybe (errMissingToken, w) runQuery (authToken (ask w))
                      query = fromResponse "tag" . Right <$> getJSONWith opts (toURI $ tagsEndpoint </> name)
                  in (query, w)
 
+-- | Delete a Tag
 --
 -- https://developers.digitalocean.com/documentation/v2/#delete-a-tag
 --
@@ -67,6 +71,7 @@ doDeleteTag w name = maybe (errMissingToken, w) runQuery (authToken (ask w))
                      query = Right () <$ deleteJSONWith opts (toURI $ tagsEndpoint </> name) body
                  in (query, w)
 
+-- | Tag one or several other resources
 --
 -- https://developers.digitalocean.com/documentation/v2/#tag-a-resource
 --
@@ -78,6 +83,7 @@ doTagResources w name pairs = maybe (errMissingToken, w) runQuery (authToken (as
                      query = Right () <$ postJSONWith opts (toURI $ tagsEndpoint </> name </> "resources") body
                  in (query, w)
 
+-- | Untag one or several other resources
 --
 -- https://developers.digitalocean.com/documentation/v2/#untag-a-resource
 --

--- a/src/Network/DO/Tags/Net.hs
+++ b/src/Network/DO/Tags/Net.hs
@@ -1,0 +1,101 @@
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | Network interpreter for Tags specific API
+module Network.DO.Tags.Net(tagsCommandsInterpreter) where
+
+import Prelude                      as P hiding (error)
+
+import Control.Comonad.Env.Class    (ComonadEnv, ask)
+import Control.Monad.Trans          (MonadIO)
+import Data.Aeson                   as A hiding (Result, pairs)
+import Data.Proxy
+import Network.DO.Tags.Commands
+import Network.DO.Net.Common
+import Network.DO.Types             as DO hiding (URI, name)
+import Network.REST
+
+
+-- Define some shortcut accessor
+tagsURI :: String
+tagsURI = "tags"
+
+tagsEndpoint :: String
+tagsEndpoint = rootURI </> apiVersion </> tagsURI
+
+
+-- Derive the listTags endpoint for free, see @Network.DO.Net.Common@
+--
+-- https://developers.digitalocean.com/documentation/v2/#list-all-tags
+--
+instance Listable Tag where
+  listEndpoint _ = tagsEndpoint
+  listField    _ = "tags"
+
+--
+-- https://developers.digitalocean.com/documentation/v2/#create-a-new-tag
+--
+doCreateTag :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> TagName -> (RESTT m (Result Tag), w a)
+doCreateTag w name = maybe (errMissingToken, w) runQuery (authToken (ask w))
+  where
+    runQuery t = let opts  = authorisation t
+                     body  = toJSON . object $ ["name" .= name]
+                     query = fromResponse "tag" <$> postJSONWith opts (toURI tagsEndpoint) body
+                 in (query, w)
+
+--
+-- https://developers.digitalocean.com/documentation/v2/#retrieve-a-tag
+--
+doRetrieveTag :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> TagName -> (RESTT m (Result Tag), w a)
+doRetrieveTag w name = maybe (errMissingToken, w) runQuery (authToken (ask w))
+  where
+    runQuery t = let opts  = authorisation t
+                     query = fromResponse "tag" . Right <$> getJSONWith opts (toURI $ tagsEndpoint </> name)
+                 in (query, w)
+
+--
+-- https://developers.digitalocean.com/documentation/v2/#delete-a-tag
+--
+doDeleteTag :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> TagName -> (RESTT m (Result ()), w a)
+doDeleteTag w name = maybe (errMissingToken, w) runQuery (authToken (ask w))
+  where
+    runQuery t = let opts  = authorisation t
+                     body  = toJSON ()
+                     query = Right () <$ deleteJSONWith opts (toURI $ tagsEndpoint </> name) body
+                 in (query, w)
+
+--
+-- https://developers.digitalocean.com/documentation/v2/#tag-a-resource
+--
+doTagResources :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> TagName -> TagPairs-> (RESTT m (Result ()), w a)
+doTagResources w name pairs = maybe (errMissingToken, w) runQuery (authToken (ask w))
+  where
+    runQuery t = let opts  = authorisation t
+                     body  = toJSON pairs
+                     query = Right () <$ postJSONWith opts (toURI $ tagsEndpoint </> name </> "resources") body
+                 in (query, w)
+
+--
+-- https://developers.digitalocean.com/documentation/v2/#untag-a-resource
+--
+doUntagResources :: (ComonadEnv ToolConfiguration w, Monad m) => w a -> TagName -> TagPairs -> (RESTT m (Result ()), w a)
+doUntagResources w name pairs = maybe (errMissingToken, w) runQuery (authToken (ask w))
+  where
+    runQuery t = let opts  = authorisation t
+                     body  = toJSON pairs
+                     query = Right () <$ deleteJSONWith opts (toURI $ tagsEndpoint </> name </> "resources") body
+                 in (query, w)
+
+
+-- | DSL Interpreter for TagsCommands into IO via the REST DSL
+tagsCommandsInterpreter :: (MonadIO m, ComonadEnv ToolConfiguration w) => w a -> CoTagsCommands (RESTT m) (w a)
+tagsCommandsInterpreter = CoTagsCommands
+                          <$> doCreateTag
+                          <*> doRetrieveTag
+                          <*> doDeleteTag
+                          <*> queryList (Proxy :: Proxy Tag)
+                          <*> doTagResources
+                          <*> doUntagResources

--- a/src/Network/DO/Types.hs
+++ b/src/Network/DO/Types.hs
@@ -733,8 +733,10 @@ instance ToJSON Volume where
 --
 -- https://developers.digitalocean.com/documentation/v2/#tags
 
+type TagName = String
+
 data Tag = Tag
-  { tagName      :: String        -- ^ The tag name
+  { tagName      :: TagName       -- ^ The tag name
   , tagResources :: TagResources  -- ^ An embedded object containing key value pairs of resource type and resource statistics
   } deriving (Show)
 

--- a/src/Network/DO/Types.hs
+++ b/src/Network/DO/Types.hs
@@ -680,6 +680,11 @@ resourceTypes = ["droplet", "volume", "backend"]
 instance Show ResourceType where
   show r = resourceTypes !! fromEnum r
 
+instance Read ResourceType where
+  readsPrec _ sz = case elemIndex sz resourceTypes of
+                    Just i  -> return (toEnum i, "")
+                    Nothing -> fail $ "cannot parse " <> sz
+
 instance FromJSON ResourceType where
   parseJSON (String v) =
     case elemIndex (unpack v) resourceTypes of

--- a/src/Network/REST/Commands.hs
+++ b/src/Network/REST/Commands.hs
@@ -23,7 +23,7 @@ data REST a = Get URI (Value -> a)
            | WaitFor Int String a
            | GetWith Options URI (Value -> a)
            | PostWith Options URI Value (Either String Value -> a)
-           | DeleteWith Options URI a
+           | DeleteWith Options URI Value a
            deriving (Functor)
 
 type RESTT = FreeT REST
@@ -41,8 +41,8 @@ postJSON uri json = liftF $ Post uri json id
 postJSONWith :: (Monad m) => Options ->  URI -> Value -> RESTT m (Either String Value)
 postJSONWith opts uri json = liftF $ PostWith opts uri json id
 
-deleteJSONWith :: (Monad m) => Options -> URI -> RESTT m ()
-deleteJSONWith opts uri = liftF $ DeleteWith opts uri ()
+deleteJSONWith :: (Monad m) => Options -> URI -> Value -> RESTT m ()
+deleteJSONWith opts uri json = liftF $ DeleteWith opts uri json ()
 
 waitFor :: (Monad m) => Int -> String -> RESTT m ()
 waitFor delay message = liftF $ WaitFor delay message ()

--- a/src/Network/REST/Conduit.hs
+++ b/src/Network/REST/Conduit.hs
@@ -70,10 +70,10 @@ runConduit debug r = do
         let value = getResponseBody response :: Value
         runConduit debug (k value)
 
-      step (Free (DeleteWith opts uri k)) = do
+      step (Free (DeleteWith opts uri val k)) = do
         request <- parseRequest $ "DELETE " ++ asString uri
-        debugRequest debug (RequestLog request)
-        void $ httpLBS $ options opts request
+        debugRequest debug (RequestLogWithBody request (Body val))
+        void $ httpLBS $ options opts $ setRequestBodyJSON val request
         runConduit debug k
 
       step (Free (Post uri val k)) = do


### PR DESCRIPTION
This PR is built on top of #2 (I can rebase on top of master or develop when #2 is merged). Compared to #2, most changes are [here](https://github.com/abailly/hdo/pull/4/files#diff-688ec28ac57c23b7e9563348b4a48163).

It introduces 2 minor changes:

- `list` commands now return elements wrapped in a `Result`. Missing tokens errors (see #3) are therefore correctly conveyed via the `Left` part of the `Result`. 

- Also, HTTP errors are now getting caught via the `toList` and `fromResponse` methods from `Network.DO.Net.Common`. In order to avoid complicating the REST commands too much, I implemented a basic guard which checks for a `message` property in the returned response value. As, every DO object is wrapped in a `{ <resource>: ... }` object, where `<resource>` stands for `tags`, `droplets` etc... This should be sufficient to catch error responses from there and lift them into the `Left` part of the Result as a text message.

As an alternative, we could slightly modify the REST DSL to return something else than a JSON-like `Value`. For instance, the Response object from HTTP.Conduit ? Or, already a `Result Value`?
Let me know.
